### PR TITLE
Support C++20

### DIFF
--- a/core/lib/CommandLine/getopt.h
+++ b/core/lib/CommandLine/getopt.h
@@ -142,7 +142,8 @@ struct option
 /* Many other libraries have conflicting prototypes for getopt, with
    differences in the consts, in stdlib.h.  To avoid compilation
    errors, only prototype getopt for the GNU C library.  */
-extern int getopt (int __argc, char *const *__argv, const char *__shortopts);
+extern int getopt (int __argc, char *const *__argv, const char *__shortopts)
+	__THROW __nonnull ((2,3));
 # endif /* __GNU_LIBRARY__ */
 
 # ifndef __need_getopt

--- a/core/lib/FileHandling/RINEX/RinexClockBase.cpp
+++ b/core/lib/FileHandling/RINEX/RinexClockBase.cpp
@@ -58,7 +58,7 @@ namespace gnsstk
 
    string RinexClockBase::writeTime(const CivilTime& dt) const
    {
-      if (dt == CommonTime::BEGINNING_OF_TIME)
+      if (dt == CivilTime(CommonTime::BEGINNING_OF_TIME))
       {
          return std::string(26, ' ');
       }
@@ -111,4 +111,3 @@ namespace gnsstk
 
 
 }  // namespace
-

--- a/core/lib/Geomatics/SatPass.cpp
+++ b/core/lib/Geomatics/SatPass.cpp
@@ -1194,7 +1194,7 @@ namespace gnsstk
             dt = N * dt;
             return;
          }
-         if (refTime == CommonTime::BEGINNING_OF_TIME)
+         if (refTime == Epoch(CommonTime::BEGINNING_OF_TIME))
          {
             refTime = firstTime;
          }

--- a/core/lib/Geomatics/SatPassUtilities.cpp
+++ b/core/lib/Geomatics/SatPassUtilities.cpp
@@ -396,7 +396,7 @@ namespace gnsstk
                   continue;
                }
 
-               if (prevtime != CommonTime::BEGINNING_OF_TIME)
+               if (prevtime != Epoch(CommonTime::BEGINNING_OF_TIME))
                {
                      // compute time since the last epoch
                   dt = obsdata.time - prevtime;


### PR DESCRIPTION
Fix compilation errors that arise when compiling with the c++20 standard.

To compile with `--std=c++20`, one can do:
```
cmake . -DCMAKE_CXX_STANDARD=20 -DCMAKE_CXX_EXTENSIONS=NO
```
We can check that the flag is used:
```console
$ make -j `nproc` VERBOSE=1
... -fPIC -std=c++20 ...
```

Tested with gcc 9.5.0 and gcc 12.1.0 on ubuntu 22.04