### PR TITLE
Fix compilation with GCC13

### DIFF
--- a/core/lib/GNSSCore/ObsID.hpp
+++ b/core/lib/GNSSCore/ObsID.hpp
@@ -47,6 +47,7 @@
 #ifndef OBSID_HPP
 #define OBSID_HPP
 
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <sstream>


### PR DESCRIPTION
With GCC13, the standard headers have changed, so cstdint has to be imported explicitly now.
https://gcc.gnu.org/gcc-13/porting_to.html