### PR TITLE
Ignore known but unimplemented sat systems when reading RINEX3

### DIFF
--- a/core/lib/NewNav/RinexNavDataFactory.cpp
+++ b/core/lib/NewNav/RinexNavDataFactory.cpp
@@ -237,7 +237,7 @@ namespace gnsstk
             }
             if (check)
             {
-               if (processEph)
+               if (processEph && (eph != nullptr))
                {
                   if (eph->validate() == expect)
                   {
@@ -267,7 +267,7 @@ namespace gnsstk
             }
             else
             {
-               if (processEph)
+               if (processEph && (eph != nullptr))
                {
                   if (!cb.process(eph))
                      return false;
@@ -585,6 +585,10 @@ namespace gnsstk
                //glo->step is algorithm configuration
             glo->fixFit();
             break;
+         case SatelliteSystem::Geosync:
+         case SatelliteSystem::IRNSS:
+            // These GNSSes are not supported but are expected, so do not fail
+            break;
          default:
                /// @todo add other GNSSes
             rv = false;
@@ -692,6 +696,10 @@ namespace gnsstk
                // GLOFNavHealth
             glo->healthBits = navIn.health << 2;
             healthOut.push_back(health);
+            break;
+         case SatelliteSystem::Geosync:
+         case SatelliteSystem::IRNSS:
+            // These GNSSes are not supported but are expected, so do not fail
             break;
          default:
                /// @todo add other GNSSes


### PR DESCRIPTION
RINEX3 file https://igs.bkg.bund.de/root_ftp/IGS/BRDC/2024/124/BRDC00WRD_R_20241240000_01D_MN.rnx.gz contains Geosync satellite NAV messages which are not fully implemented in GNSSTk. When reading the data with `RinexNavDataFactory`, the reading immediately fails on the first Geosync satellite and makes it impossible to import the rest of the file.

This PR makes GNSSTk ignore these records instead of failing on them.

---

Reproducer:

```C++
gnsstk::NavLibrary lib;
gnsstk::NavDataFactoryPtr fac = std::make_shared<gnsstk::RinexNavDataFactory>();
fac->addDataSource(std::string(TEST_CACHE_DIR) + "BRDC00WRD_R_20241240000_01D_MN.rnx");
lib.addFactory(fac);
std::cout << gnsstk::printTime(gnsstk::CivilTime(lib.getInitialTime()), "%Y-%m-%d %H:%M:%f") << " --- "
          << gnsstk::printTime(gnsstk::CivilTime(lib.getFinalTime()), "%Y-%m-%d %H:%M:%f") << std::endl;
```

Output without this PR:

```
4713-1-1 0:0:0.000000 --- -4713-1-1 0:0:0.000000
```

Output with this PR:

```
2024-5-2 22:0:0.000000 --- 2024-5-4 0:25:0.000000
```