### PR TITLE
Add version check to Glonass Slot Freq No header

### DIFF
--- a/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
+++ b/core/lib/FileHandling/RINEX3/Rinex3ObsHeader.cpp
@@ -934,7 +934,7 @@ namespace gnsstk
                }
             }
          }
-         else if(mapObsTypes.find("R") != mapObsTypes.end())
+         else if(version >= 3.02 && (mapObsTypes.find("R") != mapObsTypes.end()))
          {
             FFStreamError err("Glonass Slot Freq No required for files containing Glonass Observations ");
             GNSSTK_THROW(err);


### PR DESCRIPTION
### Issue
When printing a Rinex3ObsHeader, version 3.01 files will throw an error if there is no Glonass slot and frequency information. This field (GLONASS SLOT / FRQ #) is optional in version 3.01, and should not emit an error when missing.

### Change
Will only throw an exception when missing Glonass slot and frequency information if the Rinex version is 3.02 or higher.